### PR TITLE
Add PageSize param to product collection

### DIFF
--- a/Model/Search/Product.php
+++ b/Model/Search/Product.php
@@ -117,8 +117,8 @@ class Product implements \MageWorx\SearchSuiteAutocomplete\Model\SearchInterface
                                                  ->addAttributeToSelect(
                                                      [ProductFields::DESCRIPTION, ProductFields::SHORT_DESCRIPTION]
                                                  )
+                                                 ->setPageSize($productResultNumber)
                                                  ->addSearchFilter($queryText);
-        $productCollection->getSelect()->limit($productResultNumber);
 
         return $productCollection;
     }


### PR DESCRIPTION
Param PageSize used in Magento 2.3.2 CE for creating searchCriteriaResolver:
\Magento\CatalogSearch\Model\ResourceModel\Fulltext\Collection::getSearchCriteriaResolver()